### PR TITLE
Should resolve data.table 1.9.5 issue in tmGenerateRect.R

### DIFF
--- a/pkg/R/tmGenerateRect.R
+++ b/pkg/R/tmGenerateRect.R
@@ -54,10 +54,9 @@ tmGenerateRect <- function(datlist, vps, indexList, algorithm) {
         if (i!=1) {
             active <- datlist$l==i
             parents_active <- datlist$l==(i-1)
-            
-            parent_names <- apply(datlist[, paste0("index", 1:(i-1)), with=FALSE], 
+            iminusone <- i-1
+            parent_names <- apply(datlist[, paste0("index", 1:iminusone), with=FALSE], 
                                   1, paste, collapse="_")
-            
             parents1 <- parent_names[active]
             parents2 <- parent_names[parents_active]
             matchID <- match(parents1, parents2)


### PR DESCRIPTION
Minor tweak that should resolve the data.table 1.9.5 related problem (clash of variable/column name scoping)
https://github.com/Rdatatable/data.table/issues/1216
