### PR TITLE
make devtools only "require"d

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,2 +1,2 @@
-library(devtools)
+require(devtools)
 setwd("pkg")


### PR DESCRIPTION
..., rather than called by library.  Hopefully this will fix https://github.com/mtennekes/treemap/issues/23.  The problem with deploying an app to shinyapps.io might be caused by this repository expecting devtools to be installed, while it isn't an explicit dependency.  As devtools isn't really needed to load treemap (but is to build it), a possible solution is to call it only by require() rather than library().