### PR TITLE
add format.legend arguments to treemaps for value, density and manual.

### DIFF
--- a/examples/treemap.R
+++ b/examples/treemap.R
@@ -6,7 +6,8 @@ treemap(GNI2014,
        index=c("continent", "iso3"),
        vSize="population",
        vColor="GNI",
-       type="value")
+       type="value",
+       format.legend = list(scientific = FALSE, big.mark = " "))
 
 #########################################
 ### extended examples with fictive business statistics data

--- a/pkg/R/dens2col.R
+++ b/pkg/R/dens2col.R
@@ -1,5 +1,5 @@
 dens2col <-
-function(dat, position.legend, palette, range, border.col, fontfamily.legend, n) {
+function(dat, position.legend, palette, range, border.col, fontfamily.legend, n, format.legend) {
 	color <- colorRampPalette(palette,space="rgb")(99)
 
     values <- dat$c
@@ -23,8 +23,10 @@ function(dat, position.legend, palette, range, border.col, fontfamily.legend, n)
 	legScale <- floor((prettyP - minP) / (maxP - minP) * 98) + 1
 	legCol <- color[legScale]
 	
-	
-	if (position.legend!="none") drawLegend(prettyT, legCol,
+	args.legend <- format.legend
+	args.legend[["x"]] <- prettyT
+	legendText <- do.call("format", args.legend)
+	if (position.legend!="none") drawLegend(legendText, legCol,
 											position.legend=="bottom", border.col, fontfamily.legend)
 
 	scale <- floor((values - minP) / (maxP - minP) * 98) + 1

--- a/pkg/R/tmColorsLegend.R
+++ b/pkg/R/tmColorsLegend.R
@@ -1,4 +1,4 @@
-tmColorsLegend <- function(datlist, vps, position.legend, type, palette, range, mapping, indexNames, palette.HCL.options, border.col, fontfamily.legend, n) {
+tmColorsLegend <- function(datlist, vps, position.legend, type, palette, range, mapping, indexNames, palette.HCL.options, border.col, fontfamily.legend, n, format.legend = format.legend) {
     if (position.legend!="none") {    
         pushViewport(vps$vpLeg)
     }
@@ -6,15 +6,15 @@ tmColorsLegend <- function(datlist, vps, position.legend, type, palette, range, 
     res <- if (type == "comp") {
         comp2col(datlist, position.legend, palette, range, border.col, fontfamily.legend, n=n)
     } else if (type == "dens") {
-        dens2col(datlist, position.legend, palette, range, border.col, fontfamily.legend, n=n) 
+        dens2col(datlist, position.legend, palette, range, border.col, fontfamily.legend, n=n, format.legend = format.legend) 
     } else if (type == "depth") {
         depth2col(datlist, position.legend, palette, indexNames, palette.HCL.options, border.col, fontfamily.legend)
     } else if (type == "index") {
         index2col(datlist, position.legend, palette, levels(datlist$index1), palette.HCL.options, border.col, fontfamily.legend)
     } else if (type == "value") {
-        value2col(datlist, position.legend, palette, range, mapping, border.col, fontfamily.legend, auto.col.mapping=TRUE, n=n)
+        value2col(datlist, position.legend, palette, range, mapping, border.col, fontfamily.legend, auto.col.mapping=TRUE, n=n, format.legend = format.legend)
     } else if (type == "manual") {
-        value2col(datlist, position.legend, palette, range, mapping, border.col, fontfamily.legend, auto.col.mapping=FALSE, n=n)
+        value2col(datlist, position.legend, palette, range, mapping, border.col, fontfamily.legend, auto.col.mapping=FALSE, n=n, format.legend = format.legend)
     } else if (type == "categorical") {
         cat2col(datlist, position.legend, palette, levels(datlist$c), palette.HCL.options, border.col, fontfamily.legend)
     }

--- a/pkg/R/treemap.R
+++ b/pkg/R/treemap.R
@@ -63,6 +63,7 @@
 #' @param ymod.labels the vertical position modification of the labels in inches. Either a single value, or a vector that specifies the modification for each aggregation level.
 #' @param eval.labels should the text labels, i.e. the factor labels of the \code{index} variables, be evaluated as expressions? Useful for printing mathematical symbols or equations.
 #' @param position.legend position of the legend: \code{"bottom"}, \code{"right"}, or \code{"none"}. For "categorical" and "index" treemaps, \code{"right"} is the default value, for "index" treemap, \code{"none"}, and for the other types, \code{"bottom"}.
+#' @param format.legend a list of additional arguments for the formatting of numbers in the legend to pass to \code{format()}; only applies if \code{type} is \code{"value"}, \code{"dens"} or \code{"manual"}.
 #' @param drop.unused.levels logical that determines whether unused levels (if any) are shown in the legend. Applicable for "categorical" treemap type.
 #' @param aspRatio preferred aspect ratio of the main rectangle, defined by width/height. When set to \code{NA}, the available window size is used.
 #' @param vp \code{\link[grid:viewport]{viewport}} to draw in. By default it is not specified, which means that a new plot is created. Useful when drawing small multiples, or when placing a treemap in a custom grid based plot.
@@ -133,6 +134,7 @@ treemap <-
              ymod.labels = 0,
              eval.labels = FALSE,
              position.legend=NULL,
+             format.legend=NULL,
              drop.unused.levels = TRUE,
              aspRatio=NA,
              vp=NULL,
@@ -529,7 +531,7 @@ treemap <-
             datlist$colorvalue <- NA
         } else {
             attr(datlist, "range") <- 1:2
-            datlist <- tmColorsLegend(datlist, vps, position.legend, type, palette, range, mapping, indexNames=index, palette.HCL.options=palette.HCL.options, border.col, fontfamily.legend, n)
+            datlist <- tmColorsLegend(datlist, vps, position.legend, type, palette, range, mapping, indexNames=index, palette.HCL.options=palette.HCL.options, border.col, fontfamily.legend, n, format.legend)
         }
         datlist <- tmGenerateRect(datlist, vps, indexList, algorithm)
         

--- a/pkg/R/value2col.R
+++ b/pkg/R/value2col.R
@@ -1,5 +1,5 @@
 value2col <-
-    function(dat, position.legend, palette, range, mapping, border.col, fontfamily.legend, auto.col.mapping, n) {
+    function(dat, position.legend, palette, range, mapping, border.col, fontfamily.legend, auto.col.mapping, n, format.legend) {
         maxlev <- max(dat$l)
         
  
@@ -55,10 +55,11 @@ value2col <-
         prettyV.ids[prettyV.ids < 1] <- 1
         prettyV.ids[prettyV.ids > 101] <- 101
         
-            
         colpal <- colorRampPalette(palette)(101)
-        
-        if (position.legend!="none") drawLegend(format(prettyV), colpal[prettyV.ids], position.legend=="bottom", border.col, fontfamily.legend)
+        args.legend <- format.legend
+        args.legend[["x"]] <- prettyV
+        legendText <- do.call("format", args.legend)
+        if (position.legend!="none") drawLegend(legendText, colpal[prettyV.ids], position.legend=="bottom", border.col, fontfamily.legend)
         
         return (list(colpal[value.ids], range(prettyV), values_all))
     }

--- a/pkg/man/treemap.Rd
+++ b/pkg/man/treemap.Rd
@@ -17,8 +17,8 @@ treemap(dtf, index, vSize, vColor = NULL, stdErr = NULL, type = "index",
   lowerbound.cex.labels = 0.4, inflate.labels = FALSE, bg.labels = NULL,
   force.print.labels = FALSE, overlap.labels = 0.5,
   align.labels = c("center", "center"), xmod.labels = 0, ymod.labels = 0,
-  eval.labels = FALSE, position.legend = NULL, drop.unused.levels = TRUE,
-  aspRatio = NA, vp = NULL, draw = TRUE, ...)
+  eval.labels = FALSE, position.legend = NULL, format.legend = NULL,
+  drop.unused.levels = TRUE, aspRatio = NA, vp = NULL, draw = TRUE, ...)
 }
 \arguments{
 \item{dtf}{a data.frame. Required.}
@@ -120,6 +120,8 @@ treemap(dtf, index, vSize, vColor = NULL, stdErr = NULL, type = "index",
 
 \item{position.legend}{position of the legend: \code{"bottom"}, \code{"right"}, or \code{"none"}. For "categorical" and "index" treemaps, \code{"right"} is the default value, for "index" treemap, \code{"none"}, and for the other types, \code{"bottom"}.}
 
+\item{format.legend}{a list of additional arguments for the formatting of numbers in the legend to pass to \code{format()}; only applies if \code{type} is \code{"value"}, \code{"dens"} or \code{"manual"}.}
+
 \item{drop.unused.levels}{logical that determines whether unused levels (if any) are shown in the legend. Applicable for "categorical" treemap type.}
 
 \item{aspRatio}{preferred aspect ratio of the main rectangle, defined by width/height. When set to \code{NA}, the available window size is used.}
@@ -192,7 +194,8 @@ treemap(business,
         index=c("NACE1", "NACE2"),
         vSize="employees",
         vColor="employees.prev",
-        type="comp")
+        type="comp",
+        format.legend = list(scientific = FALSE, big.mark = ","))
 
 # density treemaps: colors indicate density (like a population density map)
 treemap(business,


### PR DESCRIPTION
Key things to consider before accepting this:

* I've applied it to treemaps of type "value", "density" and "manual".  I'm far from sure this is right (either too many or not enough), needs review / thinking.

* I've called the argument `format.legend` to make it consistent with `position.legend`.  However, `tmap` has `legend.format`.  @mtennekes to make a call on the right way to do it.

* I've made a single addition to the examples, just for the basic example (GNI, in my opinion fits best).

* I haven't changed the version or anything.

* anything else I haven't noticed.