### PR TITLE
in R 4.0 matrix() inherits also from "array"

### DIFF
--- a/pkg/R/treemap.R
+++ b/pkg/R/treemap.R
@@ -321,7 +321,7 @@ treemap <-
                 if (palette[1]=="HCL" && !(type %in% c("depth", "index", "categorical"))) {
                     stop("HCL palette only applicable for treemap types \"depth\", \"index\" and \"categorical\".")
                 }
-                if (palette[1]!="HCL") if (class(try(col2rgb(palette), silent=TRUE))=="try-error") 
+                if (palette[1]!="HCL") if (is(try(col2rgb(palette), silent=TRUE)), "try-error")
                     stop("color palette is not correct")
             }
         }


### PR DESCRIPTION
The original code produces a warning in R >=4.0 since [in R 4.0 matrix() inherits also from "array"](https://developer.r-project.org/Blog/public/2019/11/09/when-you-think-class.-think-again/index.html)

```r
R> palette <- colors()[1:3]
R> palette
[1] "white"        "aliceblue"    "antiquewhite"
R> class(try(col2rgb(palette), silent=TRUE))
[1] "matrix" "array" 
R> if (palette[1]!="HCL") if (class(try(col2rgb(palette), silent=TRUE))=="try-error") 
+ stop("color palette is not correct")
Warning message:
In if (class(try(col2rgb(palette), silent = TRUE)) == "try-error") stop("color palette is not correct") :
  the condition has length > 1 and only the first element will be used
```

The pull request uses a preferred form of querying if an object is of a class.

`sessionInfo()` output:

```r
R Under development (unstable) (2020-03-10 r77920)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 18.04.4 LTS

Matrix products: default
BLAS:   /home/sergi/bin/R-4.0/lib/R/lib/libRblas.so
LAPACK: /home/sergi/bin/R-4.0/lib/R/lib/libRlapack.so

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C               LC_TIME=en_US.UTF-8        LC_COLLATE=en_US.UTF-8    
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8    LC_PAPER=en_US.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C             LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  utils     datasets  grDevices methods   base     

loaded via a namespace (and not attached):
[1] compiler_4.0.0 parallel_4.0.0
```